### PR TITLE
Allows --pex-args to take an argument

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -14,7 +14,7 @@ class bdist_pex(Command):
   user_options = [
       ('bdist-all', None, 'pexify all defined entry points'),
       ('bdist-dir', None, 'the directory into which pexes will be written, default: dist.'),
-      ('pex-args', None, 'additional arguments to the pex tool'),
+      ('pex-args=', None, 'additional arguments to the pex tool'),
   ]
 
   boolean_options = [


### PR DESCRIPTION
Prevents this error:

```
$ python setup.py bdist_pex --pex-args='-r gunicorn-req.txt -r ipython-req.txt'
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --pex-args must not have an argument
```
