### PR TITLE
Don't choke if pkg has no console_scripts

### DIFF
--- a/pex/commands/bdist_pex.py
+++ b/pex/commands/bdist_pex.py
@@ -61,7 +61,7 @@ class bdist_pex(Command):
         log.info('Writing %s to %s.pex' % (script_name, script_name))
         self._write(pex_builder, script_name, script=script_name)
     else:
-      if len(self.distribution.entry_points['console_scripts']) == 1:
+      if len(self.distribution.entry_points.get('console_scripts', [])) == 1:
         script_name = self.distribution.entry_points['console_scripts'][0].split('=')[0].strip()
         log.info('Writing %s to %s.pex' % (script_name, name))
         self._write(pex_builder, name, script=script_name)


### PR DESCRIPTION
Prevents this error:

```
$ python setup.py bdist_pex --pex-args="--index-url=http://packages.corp.surveymonkey.com/index"
running bdist_pex
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    pbr=True
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/Users/marca/dev/git-repos/pex/pex/commands/bdist_pex.py", line 64, in run
    if len(self.distribution.entry_points['console_scripts']) == 1:
KeyError: 'console_scripts'
```
